### PR TITLE
Fix binary build

### DIFF
--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -3,4 +3,4 @@
 EXPORTER_SOURCE="/build/coriolis-ovm-exporter"
 
 cd $EXPORTER_SOURCE/cmd/exporter
-go build -o $EXPORTER_SOURCE/coriolis-ovm-exporter -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --always --dirty)" .
+go build -buildvcs=false -o $EXPORTER_SOURCE/coriolis-ovm-exporter -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --always --dirty)" .


### PR DESCRIPTION
Fixes Go build that errors because it cannot read VCS stamping. It does that by disabling VCS building.